### PR TITLE
Fixed x86_64 GDT

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -6,7 +6,7 @@ $(ARCH_OBJS) \
 kernel/kernel.o \
 kernel/string.o \
 kernel/util.o \
-kernel/cxx.o \
+kernel/cxx.o
 
 .PHONY: all
 all: kernel.bin

--- a/kernel/arch/i386/make.config
+++ b/kernel/arch/i386/make.config
@@ -1,4 +1,4 @@
-ARCH_OBJS:=\
+ARCH_OBJS:= \
 $(ARCHDIR)/boot.o \
 $(ARCHDIR)/util.o \
 $(ARCHDIR)/../x86_shared/error.o \
@@ -6,4 +6,4 @@ $(ARCHDIR)/../x86_shared/sse.o \
 $(ARCHDIR)/../x86_shared/arch.o \
 $(ARCHDIR)/../x86_shared/vga.o \
 $(ARCHDIR)/../x86_shared/gdt.o \
-$(ARCHDIR)/../x86_shared/idt.o \
+$(ARCHDIR)/../x86_shared/idt.o

--- a/kernel/arch/x86_64/make.config
+++ b/kernel/arch/x86_64/make.config
@@ -1,4 +1,4 @@
-ARCH_OBJS:=\
+ARCH_OBJS:= \
 $(ARCHDIR)/boot.o \
 $(ARCHDIR)/util.o \
 $(ARCHDIR)/../x86_shared/error.o \
@@ -6,6 +6,4 @@ $(ARCHDIR)/../x86_shared/sse.o \
 $(ARCHDIR)/../x86_shared/arch.o \
 $(ARCHDIR)/../x86_shared/vga.o \
 $(ARCHDIR)/../x86_shared/gdt.o \
-$(ARCHDIR)/../x86_shared/idt.o \
-
-
+$(ARCHDIR)/../x86_shared/idt.o

--- a/kernel/arch/x86_64/util.asm
+++ b/kernel/arch/x86_64/util.asm
@@ -1,23 +1,36 @@
 .global loadGDT
 .section .text
 loadGDT:
-    # pop the return adress from the stack
-    pop %rax
-    push $0x10
-    push %rsp
+    # Save the current stack pointer on the stack to push later
+    popq %rax
+    pushq %rsp
+
+    # push ss
+    pushq $0x10
+
+    # push rsp
+    pushq 8(%rsp)
+
 
     pushfq
-    # call reloadCS
-    push $0x08
+    # push cs
+    pushq $0x08
+    # push eip back on
+    pushq %rax
 
-    # push our return adress
-    push %rax
+    call reloadCS
+
     iretq
+
 reloadCS:
+    pushw %ax
+
     movw $0x10, %ax
     mov %ax, %ds
     mov %ax, %es
     mov %ax, %fs
     mov %ax, %gs
     mov %ax, %ss
+
+    popw %ax
     ret

--- a/kernel/arch/x86_shared/gdt.cpp
+++ b/kernel/arch/x86_shared/gdt.cpp
@@ -1,11 +1,25 @@
 #include "gdt.hpp"
 
-extern "C" void loadGDT();
+extern "C" int loadGDT();
 
 static SegmentDescriptor invalid;
 
 SegmentDescriptor GDT::s_descriptors[GDT::s_length] = {
     SegmentDescriptor(),
+#ifdef _x86_64_
+  SegmentDescriptor(0x00000000, 0x00000000,
+                      SA_PRESENT | SA_EXECUTABLE | SA_READABLE | SA_SEGMENT | SA_RING0,
+                      SF_LONGMODE),
+  SegmentDescriptor(0x00000000, 0x00000000,
+                      SA_PRESENT | SA_WRITABLE | SA_SEGMENT | SA_RING0,
+                      0),
+  SegmentDescriptor(0x00000000, 0x00000000,
+                      SA_PRESENT | SA_EXECUTABLE | SA_READABLE | SA_SEGMENT | SA_RING3,
+                      SF_LONGMODE),
+  SegmentDescriptor(0x00000000, 0x00000000,
+                      SA_PRESENT | SA_WRITABLE | SA_SEGMENT | SA_RING3,
+                      0),
+#elif _i386_
     SegmentDescriptor(0x00000000, 0xFFFFFFFF,
                       SA_PRESENT | SA_EXECUTABLE | SA_SEGMENT | SA_RING0,
                       SF_USE4KSIZE | SF_USE32BIT),
@@ -18,6 +32,7 @@ SegmentDescriptor GDT::s_descriptors[GDT::s_length] = {
     SegmentDescriptor(0x00000000, 0xFFFFFFFF,
                       SA_PRESENT | SA_WRITABLE | SA_SEGMENT | SA_RING3,
                       SF_USE4KSIZE | SF_USE32BIT),
+#endif
     SegmentDescriptor(),
     SegmentDescriptor(),
     SegmentDescriptor()};
@@ -33,11 +48,21 @@ void GDT::Initialize() {
 
   struct {
     uint16_t limit;
+
     void *pointer;
   } __attribute__((packed)) gdtp = {
       .limit = GDT::s_length * sizeof(SegmentDescriptor) - 1,
       .pointer = &GDT::s_descriptors,
   };
+
+
+#ifdef _x86_64_
+  static_assert(sizeof(gdtp) == 10,
+              "InterruptDescriptor must be 6 bytes long in Longmode.");
+#elif _i386_
+  static_assert(sizeof(gdtp) == 6,
+              "InterruptDescriptor must be 8 bytes long in 32-bit mode.");
+#endif
 
   asm volatile("lgdt %0" : : "m"(gdtp));
 

--- a/kernel/arch/x86_shared/gdt.hpp
+++ b/kernel/arch/x86_shared/gdt.hpp
@@ -20,8 +20,15 @@ enum SegmentAccess : uint8_t {
 enum SegmentFlags : uint8_t {
   SF_NONE = 0,
   SF_AVAILABE = (1 << 0),
-  SF_LONGMODE = (1 << 1),
+
+  // When set, the D bit (SF_USE32BIT) must be cleared.
+  // Must be 0 when not in IA-32e mode or for non-code segments
+  SF_LONGMODE = (1 << 1), 
+
+  // Default size; set for 32 bit, unset for 16 bit
   SF_USE32BIT = (1 << 2),
+
+  // Granularity
   SF_USE4KSIZE = (1 << 3),
 };
 

--- a/kernel/arch/x86_shared/idt.hpp
+++ b/kernel/arch/x86_shared/idt.hpp
@@ -19,8 +19,8 @@ struct InterruptFlags {
 struct InterruptDescriptor {
   uint16_t offset_1;
   uint16_t selector;
-  uint8_t ist_index : 2; // LM only
-  uint8_t reserved : 6;
+  uint8_t ist_index : 3; // LM only
+  uint8_t reserved : 5;
   InterruptFlags flags;
   uint16_t offset_2;
 #ifdef _x86_64_

--- a/kernel/kernel/util.cpp
+++ b/kernel/kernel/util.cpp
@@ -5,7 +5,7 @@ void *memcpy(void *destination, const void *source, size_t num) {
   const unsigned char *src = reinterpret_cast<const unsigned char *>(source);
 
   for (size_t i = 0; i < num; ++i) {
-    dst[i] = src[i];
+    *dst++ = *src++;
   }
 
   return destination;
@@ -14,7 +14,7 @@ void *memcpy(void *destination, const void *source, size_t num) {
 void *memset(void *ptr, int value, size_t num) {
   unsigned char *uc_ptr = reinterpret_cast<unsigned char *>(ptr);
   for (size_t i = 0; i < num; ++i) {
-    uc_ptr[i] = value;
+    *uc_ptr++ = value;
   }
 
   return ptr;


### PR DESCRIPTION
This no longer uses the iret opcode to set the code selector to 0x8. This won't be problem as long as the code selector doesn't change.